### PR TITLE
Fix typo in recommended config: onclick-has-focus

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ module.exports = {
         'jsx-a11y/mouse-events-have-key-events': 2,
         'jsx-a11y/no-access-key': 2,
         'jsx-a11y/no-onchange': 2,
-        'jsx-a11y/onclick-hs-focus': 2,
+        'jsx-a11y/onclick-has-focus': 2,
         'jsx-a11y/onclick-has-role': 2,
         'jsx-a11y/role-has-required-aria-props': 2,
         'jsx-a11y/role-supports-aria-props': 2,


### PR DESCRIPTION
I was trying to set up an eslintrc extending the recommended rules for jsx-a11y:

``` js
"extends": ["eslint:recommended", "plugin:react/recommended", "plugin:jsx-a11y/recommended"],
...
"plugins": [
    "react",
    "jsx-a11y"
]

```

And got a whole bunch of:

```
1:1  error  Definition for rule 'jsx-a11y/onclick-hs-focus' was not found  jsx-a11y/onclick-hs-focus
```
